### PR TITLE
Add Autobrk max on autostart takeoff

### DIFF
--- a/A32X-Checklists.xml
+++ b/A32X-Checklists.xml
@@ -575,6 +575,34 @@
 			<item>
 				<name>ECAM MEMO</name>
 				<value>TO NO BLUE</value>
+                                <condition>
+					<and>
+                                                <equals>
+                                                        <property>controls/autobrake/mode</property>
+                                                        <value>3</value>
+                                                </equals>
+						<equals>
+							<property>controls/switches/seatbelt-sign</property>
+							<value>true</value>
+						</equals>
+						<equals>
+							<property>controls/switches/no-smoking-sign</property>
+							<value>true</value>
+						</equals>
+                                                <equals>
+                                                        <property>controls/flight/speedbrake-arm</property>
+                                                        <value>1</value>
+                                                </equals>
+                                                <greater-than>
+							<property>controls/flight/flap-lever</property>
+							<value>0</value>
+						</greater-than>
+						<less-than>
+							<property>controls/flight/flap-lever</property>
+							<value>3</value>
+						</less-than>
+					</and>
+				</condition>
 			</item>
 			<item>
 				<name>AUTO BRK MAX</name>
@@ -805,23 +833,23 @@
 				<and>
 					<equals>
 						<property>controls/lighting/landing-lights[1]</property>
-						<value>true</value>
+						<value>1</value>
 					</equals>
 					<equals>
 						<property>controls/lighting/landing-lights[2]</property>
-						<value>true</value>
+						<value>1</value>
 					</equals>
 				</and>
 			</condition>
 			<binding>
 				<command>property-assign</command>
 				<property>controls/lighting/landing-lights[1]</property>
-				 <value>true</value>
+				 <value>1</value>
 			</binding>
 			<binding>
 				<command>property-assign</command>
 				<property>controls/lighting/landing-lights[2]</property>
-				 <value>true</value>
+				 <value>1</value>
 			</binding>
 		</item>
 		<item>
@@ -953,25 +981,25 @@
 			<value>OFF</value>
 			<condition>
 				<and>
-					<equals>
+					<less-than>
 						<property>controls/lighting/landing-lights[1]</property>
-						<value>false</value>
-					</equals>
-					<equals>
+						<value>0.5</value>
+					</less-than>
+					<less-than>
 						<property>controls/lighting/landing-lights[2]</property>
-						<value>false</value>
-					</equals>
+						<value>0.5</value>
+					</less-than>
 				</and>
 			</condition>
 			<binding>
 				<command>property-assign</command>
 				<property>controls/lighting/landing-lights[1]</property>
-                                <value>false</value>
+                                <value>0</value>
 			</binding>
 			<binding>
 				<command>property-assign</command>
 				<property>controls/lighting/landing-lights[2]</property>
-                                <value>false</value>
+                                <value>0</value>
 			</binding>
 		</item>
 		<item>
@@ -1094,6 +1122,38 @@
 		<item>
 			<name>ECAM MEMO</name>
 			<value>LDG NO BLUE</value>
+                        <condition>
+				<and>
+					<equals>
+						<property>gear/gear/position-norm</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>gear/gear[1]/position-norm</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>gear/gear[2]/position-norm</property>
+						<value>1</value>
+					</equals>
+                                        <equals>
+						<property>controls/switches/seatbelt-sign</property>
+						<value>true</value>
+					</equals>
+					<equals>
+						<property>controls/switches/no-smoking-sign</property>
+						<value>true</value>
+					</equals>
+                                        <equals>
+                                                <property>controls/flight/speedbrake-arm</property>
+                                                <value>1</value>
+                                        </equals>
+                                        <equals>
+						<property>controls/flight/flap-lever</property>
+						<value>4</value>
+					</equals>
+				</and>
+			</condition>
 		</item>
 		<item>
 			<name>L/G DOWN</name>
@@ -1164,7 +1224,7 @@
 		<item>
 			<name>FLAPS SET</name>
 			<value>GREEN</value>
-			<condition>
+                                <condition>
 					<equals>
 						<property>controls/flight/flap-lever</property>
 						<value>4</value>

--- a/AircraftConfig/acconfig.nas
+++ b/AircraftConfig/acconfig.nas
@@ -409,6 +409,7 @@ var takeoff = func {
 			setprop("/controls/flight/flap-txt", "1+F");
 			libraries.flaptimer.start();
 			setprop("/controls/flight/elevator-trim", -0.07);
+                        setprop("/controls/autobrake/mode", 3);
 		}
 	});
 }


### PR DESCRIPTION
<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
<!-- Describe your changes in detail. -->
The plane is not ready for a takeoff when the autobrakes are not set to max.
Also corrected the landing light property in the checklists.
Sorry if you see spaces but I ONLY use tabs. Maybe it's due to our different text editors (Linux: Kate, Windows: Notepad etc.).

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have an IDG Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->