### PR TITLE
Added functionality to the RMP

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1547,6 +1547,9 @@
 		<autopush_route>
 			<file>Aircraft/IDG-A32X/Nasal/autopush_route.nas</file>
 		</autopush_route>
+		<rmp>
+			<file>Aircraft/IDG-A32X/Models/Instruments/Radio/Radio.nas</file>
+		</rmp>
 	</nasal>
 
 </PropertyList>

--- a/Models/FlightDeck/a320.flightdeck.xml
+++ b/Models/FlightDeck/a320.flightdeck.xml
@@ -488,19 +488,7 @@
 		<object-name>master_caution_on</object-name>
 		<object-name>master_warning_on</object-name>
 		<object-name>qnh-test</object-name>
-		<object-name>radio_adf_led</object-name>
-		<object-name>radio_am_led</object-name>
-		<object-name>radio_bfo_led</object-name>
-		<object-name>radio_hf1_led</object-name>
-		<object-name>radio_hf2_led</object-name>
-		<object-name>radio_ls_led</object-name>
-		<object-name>radio_nav_led</object-name>
 		<object-name>radio_opt_led</object-name>
-		<object-name>radio_sel_led</object-name>
-		<object-name>radio_vhf1_led</object-name>
-		<object-name>radio_vhf2_led</object-name>
-		<object-name>radio_vhf3_led</object-name>
-		<object-name>radio_vor_led</object-name>
 		<object-name>rudder-trim-test</object-name>
 		<object-name>spd-text-test</object-name>
 		<object-name>terr_on_nd_on</object-name>

--- a/Models/Instruments/Radio/Radio.nas
+++ b/Models/Instruments/Radio/Radio.nas
@@ -9,10 +9,9 @@
 
 var rmp_update = nil;
 
-var act_vhf1 = props.globals.getNode("/instrumentation/comm[0]/frequencies/selected-mhz-fmt");
-var act_vhf2 = props.globals.getNode("/instrumentation/comm[1]/frequencies/selected-mhz-fmt");
-# TODO when VHF3 is available uncomment this
-#var act_vhf3 = props.globals.getNode("/instrumentation/comm[2]/frequencies/selected-mhz-fmt");
+var act_vhf1 = props.globals.getNode("/instrumentation/comm[0]/frequencies/selected-mhz");
+var act_vhf2 = props.globals.getNode("/instrumentation/comm[1]/frequencies/selected-mhz");
+var act_vhf3 = props.globals.initNode("/instrumentation/comm[2]/frequencies/selected-mhz", 0);
 
 var act_display_rmp1 = props.globals.initNode("/controls/radio/rmp[0]/active-display", "123.900");
 var stby_display_rmp1 = props.globals.initNode("/controls/radio/rmp[0]/standby-display", "118.700");
@@ -76,17 +75,16 @@ var update_active_vhf = func(vhf) {
 			}
 		}
 	} else {
-# TODO when VHF3 is available uncomment this
-#		if(sel1 == "vhf2" or sel2 == "vhf2") {
-#			var act = sprintf("%3.3f", act_vhf2.getValue());
-#
-#			if(sel1 == "vhf2") {
-#				act_display_rmp1.setValue(act);
-#			}
-#			if(sel2 == "vhf2") {
-#				act_display_rmp2.setValue(act);
-#			}
-#		}
+		if(sel1 == "vhf3" or sel2 == "vhf3") {
+			var act = sprintf("%3.3f", act_vhf3.getValue());
+
+			if(sel1 == "vhf3") {
+				act_display_rmp1.setValue(act);
+			}
+			if(sel2 == "vhf3") {
+				act_display_rmp2.setValue(act);
+			}
+		}
 	}
 };
 
@@ -159,19 +157,13 @@ var transfer = func(rmp_no) {
 		var mod1 = int(string.replace(sel_chan, "vhf", ""));
 		var mod = mod1 - 1;
 
-		# TODO remove this IF statement when /instrumentation/comm[2] was added
-		if(mod == 2) { return;}
-
-
 		var mem = getprop("/instrumentation/comm[" ~ mod ~ "]/frequencies/selected-mhz");
-
 		setprop("/instrumentation/comm[" ~ mod ~ "]/frequencies/selected-mhz", getprop("/systems/radio/rmp[" ~ rmp_no ~ "]/vhf" ~ mod1 ~ "-standby"));
 		setprop("/systems/radio/rmp[" ~ rmp_no ~ "]/vhf" ~ mod1 ~ "-standby", mem);
 	}
 }
 
 
-# In case that a 3rd RMP is added, increase the check in the following 3 loops to `i <= 2`
 setlistener("/systems/radio/rmp[0]/vhf1-standby", func {
 	update_stby_vhf(0, 1);
 });
@@ -197,15 +189,15 @@ setlistener("/systems/radio/rmp[1]/vhf3-standby", func {
 });
 
 setlistener("/systems/radio/rmp[2]/vhf1-standby", func {
-	update_stby_vhf(0, 1);
+	update_stby_vhf(2, 1);
 });
 
 setlistener("/systems/radio/rmp[2]/vhf2-standby", func {
-	update_stby_vhf(0, 2);
+	update_stby_vhf(2, 2);
 });
 
 setlistener("/systems/radio/rmp[2]/vhf3-standby", func {
-	update_stby_vhf(0, 3);
+	update_stby_vhf(2, 3);
 });
 
 setlistener("/instrumentation/comm[0]/frequencies/selected-mhz", func {
@@ -216,10 +208,9 @@ setlistener("/instrumentation/comm[1]/frequencies/selected-mhz", func {
 	update_active_vhf(2);
 });
 
-# In case that a 3rd RMP is added, uncomment the following lines
-#setlistener("/instrumentation/comm[2]/frequencies/selected-mhz", func {
-#	update_active_vhf(2);
-#});
+setlistener("/instrumentation/comm[2]/frequencies/selected-mhz", func {
+	update_active_vhf(3);
+});
 
 setlistener("/systems/radio/rmp[0]/sel_chan", func {
 	update_chan_sel(0);

--- a/Models/Instruments/Radio/Radio.nas
+++ b/Models/Instruments/Radio/Radio.nas
@@ -1,0 +1,234 @@
+# A3XX Radio Managment Panel
+# merspieler
+
+############################
+# Copyright (c) merspieler #
+############################
+
+# GLOBAL TODO add stuff for HF1, HF2, VOR, LS and ADF
+
+var rmp_update = nil;
+
+var act_vhf1 = props.globals.getNode("/instrumentation/comm[0]/frequencies/selected-mhz-fmt");
+var act_vhf2 = props.globals.getNode("/instrumentation/comm[1]/frequencies/selected-mhz-fmt");
+# TODO when VHF3 is available uncomment this
+#var act_vhf3 = props.globals.getNode("/instrumentation/comm[2]/frequencies/selected-mhz-fmt");
+
+var act_display_rmp1 = props.globals.initNode("/controls/radio/rmp[0]/active-display", "123.900");
+var stby_display_rmp1 = props.globals.initNode("/controls/radio/rmp[0]/standby-display", "118.700");
+var stby_rmp1_vhf1 = props.globals.initNode("/systems/radio/rmp[0]/vhf1-standby", 118.7);
+var stby_rmp1_vhf2 = props.globals.initNode("/systems/radio/rmp[0]/vhf2-standby", 123.12);
+var stby_rmp1_vhf3 = props.globals.initNode("/systems/radio/rmp[0]/vhf3-standby", 121.5);
+
+var act_display_rmp2 = props.globals.initNode("/controls/radio/rmp[1]/active-display", "127.900");
+var stby_display_rmp2 = props.globals.initNode("/controls/radio/rmp[1]/standby-display", "123.125");
+var stby_rmp2_vhf1 = props.globals.initNode("/systems/radio/rmp[1]/vhf1-standby", 118.7);
+var stby_rmp2_vhf2 = props.globals.initNode("/systems/radio/rmp[1]/vhf2-standby", 123.12);
+var stby_rmp2_vhf3 = props.globals.initNode("/systems/radio/rmp[1]/vhf3-standby", 121.5);
+
+var act_display_rmp3 = props.globals.initNode("/controls/radio/rmp[2]/active-display", "127.900");
+var stby_display_rmp3 = props.globals.initNode("/controls/radio/rmp[2]/standby-display", "123.125");
+var stby_rmp3_vhf1 = props.globals.initNode("/systems/radio/rmp[2]/vhf1-standby", 118.7);
+var stby_rmp3_vhf2 = props.globals.initNode("/systems/radio/rmp[2]/vhf2-standby", 123.12);
+var stby_rmp3_vhf3 = props.globals.initNode("/systems/radio/rmp[2]/vhf3-standby", 121.5);
+
+var chan_rmp1 = props.globals.initNode("/systems/radio/rmp[0]/sel_chan", "vhf1");
+var chan_rmp2 = props.globals.initNode("/systems/radio/rmp[1]/sel_chan", "vhf2");
+var chan_rmp3 = props.globals.initNode("/systems/radio/rmp[2]/sel_chan", "vhf3");
+
+var init = func() {
+	for(var i = 0; i < 3; i += 1) {
+		setprop("/systems/radio/rmp[" ~ i ~ "]/hf1-standby", 510);
+		setprop("/systems/radio/rmp[" ~ i ~ "]/hf2-standby", 891);
+	}
+
+	var rmp_update = maketimer(0.2, func {
+		rmp_refresh.update();
+	});
+}
+
+var update_active_vhf = func(vhf) {
+	var sel1 = chan_rmp1.getValue();
+	var sel2 = chan_rmp2.getValue();
+# In case that a 3rd RMP is added, uncomment the following line and expand the if statements with the sel3 comparison
+#	var sel3 = chan_rmp3.getValue();
+
+	if(vhf == 1) {
+		if(sel1 == "vhf1" or sel2 == "vhf1") {
+			var act = sprintf("%3.3f", act_vhf1.getValue());
+
+			if(sel1 == "vhf1") {
+				act_display_rmp1.setValue(act);
+			}
+			if(sel2 == "vhf1") {
+				act_display_rmp2.setValue(act);
+			}
+		}
+	} else if (vhf == 2) {
+		if(sel1 == "vhf2" or sel2 == "vhf2") {
+			var act = sprintf("%3.3f", act_vhf2.getValue());
+
+			if(sel1 == "vhf2") {
+				act_display_rmp1.setValue(act);
+			}
+			if(sel2 == "vhf2") {
+				act_display_rmp2.setValue(act);
+			}
+		}
+	} else {
+# TODO when VHF3 is available uncomment this
+#		if(sel1 == "vhf2" or sel2 == "vhf2") {
+#			var act = sprintf("%3.3f", act_vhf2.getValue());
+#
+#			if(sel1 == "vhf2") {
+#				act_display_rmp1.setValue(act);
+#			}
+#			if(sel2 == "vhf2") {
+#				act_display_rmp2.setValue(act);
+#			}
+#		}
+	}
+};
+
+var update_stby_vhf = func(rmp_no, vhf) {
+	if(rmp_no == 0) {
+		if(vhf == 1) {
+			var stby = sprintf("%3.3f", stby_rmp1_vhf1.getValue());
+		} else if(vhf == 2) {
+			var stby = sprintf("%3.3f", stby_rmp1_vhf2.getValue());
+		} else {
+			var stby = sprintf("%3.3f", stby_rmp1_vhf3.getValue());
+		}
+
+		stby_display_rmp1.setValue(stby);
+	} else {
+		if(vhf == 1) {
+			var stby = sprintf("%3.3f", stby_rmp2_vhf1.getValue());
+		} else if(vhf == 2) {
+			var stby = sprintf("%3.3f", stby_rmp2_vhf2.getValue());
+		} else {
+			var stby = sprintf("%3.3f", stby_rmp2_vhf3.getValue());
+		}
+
+		stby_display_rmp2.setValue(stby);
+	}
+}
+
+var update_chan_sel = func(rmp_no) {
+	update_active_vhf(1);
+	update_active_vhf(2);
+	update_active_vhf(3);
+
+	if(rmp_no == 0) {
+		var chan = chan_rmp1.getValue();
+		if(chan == "vhf1") {
+			update_stby_vhf(rmp_no, 1);
+		} else if(chan == "vhf1") {
+			update_stby_vhf(rmp_no, 2);
+		} else {
+			update_stby_vhf(rmp_no, 3);
+		}
+	} else if(rmp_no == 1) {
+		var chan = chan_rmp2.getValue();
+		if(chan == "vhf1") {
+			update_stby_vhf(rmp_no, 1);
+		} else if(chan == "vhf2") {
+			update_stby_vhf(rmp_no, 2);
+		} else {
+			update_stby_vhf(rmp_no, 3);
+		}
+	} else {
+# In case that a 3rd RMP is added, uncomment this
+#		var chan = chan_rmp3.getValue();
+#		if(chan == "vhf1") {
+#			update_stby_vhf(rmp_no, 1);
+#		} else if(chan == "vhf2") {
+#			update_stby_vhf(rmp_no, 2);
+#		} else {
+#			update_stby_vhf(rmp_no, 3);
+#		}
+	}
+}
+
+var transfer = func(rmp_no) {
+
+	rmp_no = rmp_no - 1;
+	var sel_chan = getprop("/systems/radio/rmp[" ~ rmp_no ~ "]/sel_chan");
+
+	if(string.match(sel_chan, "vhf[1-3]")) {
+		var mod1 = int(string.replace(sel_chan, "vhf", ""));
+		var mod = mod1 - 1;
+
+		# TODO remove this IF statement when /instrumentation/comm[2] was added
+		if(mod == 2) { return;}
+
+
+		var mem = getprop("/instrumentation/comm[" ~ mod ~ "]/frequencies/selected-mhz");
+
+		setprop("/instrumentation/comm[" ~ mod ~ "]/frequencies/selected-mhz", getprop("/systems/radio/rmp[" ~ rmp_no ~ "]/vhf" ~ mod1 ~ "-standby"));
+		setprop("/systems/radio/rmp[" ~ rmp_no ~ "]/vhf" ~ mod1 ~ "-standby", mem);
+	}
+}
+
+
+# In case that a 3rd RMP is added, increase the check in the following 3 loops to `i <= 2`
+setlistener("/systems/radio/rmp[0]/vhf1-standby", func {
+	update_stby_vhf(0, 1);
+});
+
+setlistener("/systems/radio/rmp[0]/vhf2-standby", func {
+	update_stby_vhf(0, 2);
+});
+
+setlistener("/systems/radio/rmp[0]/vhf3-standby", func {
+	update_stby_vhf(0, 3);
+});
+
+setlistener("/systems/radio/rmp[1]/vhf1-standby", func {
+	update_stby_vhf(1, 1);
+});
+
+setlistener("/systems/radio/rmp[1]/vhf2-standby", func {
+	update_stby_vhf(1, 2);
+});
+
+setlistener("/systems/radio/rmp[1]/vhf3-standby", func {
+	update_stby_vhf(1, 3);
+});
+
+setlistener("/systems/radio/rmp[2]/vhf1-standby", func {
+	update_stby_vhf(0, 1);
+});
+
+setlistener("/systems/radio/rmp[2]/vhf2-standby", func {
+	update_stby_vhf(0, 2);
+});
+
+setlistener("/systems/radio/rmp[2]/vhf3-standby", func {
+	update_stby_vhf(0, 3);
+});
+
+setlistener("/instrumentation/comm[0]/frequencies/selected-mhz", func {
+	update_active_vhf(1);
+});
+
+setlistener("/instrumentation/comm[1]/frequencies/selected-mhz", func {
+	update_active_vhf(2);
+});
+
+# In case that a 3rd RMP is added, uncomment the following lines
+#setlistener("/instrumentation/comm[2]/frequencies/selected-mhz", func {
+#	update_active_vhf(2);
+#});
+
+setlistener("/systems/radio/rmp[0]/sel_chan", func {
+	update_chan_sel(0);
+});
+
+setlistener("/systems/radio/rmp[1]/sel_chan", func {
+	update_chan_sel(1);
+});
+
+setlistener("/systems/radio/rmp[2]/sel_chan", func {
+	update_chan_sel(2);
+});

--- a/Models/Instruments/Radio/Radio1.xml
+++ b/Models/Instruments/Radio/Radio1.xml
@@ -1,13 +1,1518 @@
-<?xml version="1.0"?>
-
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-##############################################
-# Copyright (c) Joshua Davidson (it0uchpods) #
-##############################################
+############################
+# Copyright (c) merspieler #
+############################
 -->
+
 
 <PropertyList>
 
 	<path>res/Radio1.ac</path>
-	
+
+	<!-- On Switch -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_on</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>false</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>controls/radio/rmp[0]/on</property>
+			</binding>
+		</action>
+	</animation>
+	<animation>
+		<type>rotate</type>
+		<object-name>radio_on</object-name>
+		<property>controls/radio/rmp[0]/on</property>
+		<interpolation>
+			<entry>
+				<ind>0</ind>
+				<dep>20</dep>
+			</entry>
+			<entry>
+				<ind>1</ind>
+				<dep>-20</dep>
+			</entry>
+		</interpolation>
+		<axis>
+			<object-name>radio_on.axis</object-name>
+		</axis>
+	</animation>
+
+	<!-- VHF1 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vhf1</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>vhf1</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- VHF2 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vhf2</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>vhf2</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- VHF3 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vhf3</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>vhf3</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- HF1 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_hf1</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>hf1</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- HF2 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_hf2</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>hf2</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- AM Mode -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_am</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>systems/radio/rmp[0]/am-active</property>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<or>
+							<equals>
+								<property>systems/radio/rmp[0]/sel_chan</property>
+								<value>hf1</value>
+							</equals>
+							<equals>
+								<property>systems/radio/rmp[0]/sel_chan</property>
+								<value>hf2</value>
+							</equals>
+						</or>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- Transfer -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_exchange</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>nasal</command>
+				<script>rmp.transfer(1);</script>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- Knob -->
+	<!-- TODO add bindings for VOR, LS and ADF -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_rot1</object-name>
+		<action>
+			<button>0</button>
+			<button>3</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf1-standby</property>
+				<step>0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf2-standby</property>
+				<step>0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf3-standby</property>
+				<step>0.025</step>
+				<resolution>0.025</resolution>
+				<min>0.0</min>
+				<max>1.0</max>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf1-standby</property>
+				<step>1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf2-standby</property>
+				<step>1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+		</action>
+		<action>
+			<button>1</button>
+			<button>4</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf1-standby</property>
+				<step>-0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf2-standby</property>
+				<step>-0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf3-standby</property>
+				<step>-0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf1-standby</property>
+				<step>-1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf2-standby</property>
+				<step>-1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+		</action>
+	</animation>
+	<animation>
+		<type>pick</type>
+		<object-name>radio_rot0</object-name>
+		<action>
+			<button>0</button>
+			<button>3</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf1-standby</property>
+				<step>1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf2-standby</property>
+				<step>1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf3-standby</property>
+				<step>1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf1-standby</property>
+				<step>100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf2-standby</property>
+				<step>100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+		</action>
+		<action>
+			<button>1</button>
+			<button>4</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf1-standby</property>
+				<step>-1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf2-standby</property>
+				<step>-1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/vhf3-standby</property>
+				<step>-1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf1-standby</property>
+				<step>-100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[0]/hf2-standby</property>
+				<step>-100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+		</action>
+	</animation>
+
+	<!-- NAV Protector -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_nav_lit</object-name>
+		<action>
+			<button>1</button>
+			<binding>
+				<command>property-assign</command>
+				<property>controls/radio/rmp[0]/nav-protect</property>
+				<value>1</value>
+			</binding>
+			<mod-up>
+				<binding>
+					<command>property-assign</command>
+					<property>controls/radio/rmp[0]/nav-protect</property>
+					<value>0</value>
+				</binding>
+				<binding>
+					<command>nasal</command>
+					<script>setprop("/sim/sounde/oh-cover", 1);</script>
+				</binding>
+			</mod-up>
+		</action>
+	</animation>
+	<animation>
+		<type>rotate</type>
+		<object-name>radio_nav_lit</object-name>
+		<property>controls/radio/rmp[0]/nav-protect</property>
+		<factor>-90</factor>
+		<axis>
+			<object-name>radio_nav_lit.axis</object-name>
+		</axis>
+	</animation>
+
+	<!-- NAV -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_nav</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>systems/radio/rmp[0]/nav</property>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>controls/radio/rmp[0]/nav-protect</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- STBY NAV -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vor</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>vor</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/nav</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<animation>
+		<type>pick</type>
+		<object-name>radio_ls</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>ls</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/nav</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<animation>
+		<type>pick</type>
+		<object-name>radio_adf</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[0]/sel_chan</property>
+				<value>adf</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/nav</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<animation>
+		<type>pick</type>
+		<object-name>radio_bfo</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>systems/radio/rmp[0]/bfo-active</property>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc-ess</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[0]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/nav</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value>adf</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- SEL Light -->
+	<animation>
+		<type>select</type>
+		<object-name>radio_sel_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+					<or>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[2]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[2]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</or>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<!-- Status Lights -->
+	<animation>
+		<type>select</type>
+		<object-name>radio_vhf1_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">vhf1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_vhf2_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">vhf2</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_vhf3_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">vhf3</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_hf1_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">hf1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_hf2_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">hf2</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_nav_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/nav</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_vor_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">vor</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_ls_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">ls</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_adf_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/sel_chan</property>
+						<value type="string">adf</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_bfo_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/bfo-active</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_am_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc-ess</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[0]/am-active</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[0]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<!-- Active Display -->
+	<animation>
+		<type>select</type>
+		<object-name>rmp1-active</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[0]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc-ess</property>
+					<value>25</value>
+				</greater-than-equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp1-active</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.21549</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">%s</format>
+		<property>controls/radio/rmp[0]/active-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- Test Illumination-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp1-active-test</object-name>
+		<condition>
+			<equals>
+				<property>controls/switches/annun-test</property>
+				<value>1</value>
+			</equals>
+		</condition>
+	</animation>
+
+        <text>
+                <name>rmp1-active-test</name>
+                <offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.21549</y-m>
+			<z-m>-0.12613</z-m>
+                        <heading-deg>90</heading-deg>
+                </offsets>
+                <alignment>center-center</alignment>
+                <axis-alignment>xy-plane</axis-alignment>
+                <type type="string">text-value</type>
+                <format type="string">888.888</format>
+                <property>autopilot/servicable</property>
+                <truncate type="bool">false</truncate>
+                <font type="string">led.txf</font>
+                <draw-text type="bool">true</draw-text>
+                <draw-alignment type="bool">false</draw-alignment>
+                <draw-boundingbox type="bool">false</draw-boundingbox>
+                <character-size>0.008</character-size>
+                <font-resolution>
+                        <width type="int">32</width>
+                        <height type="int">32</height>
+                </font-resolution>
+        </text>
+
+	<!-- STBY Display -->
+	<animation>
+		<type>select</type>
+		<object-name>rmp1-standby</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[0]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc-ess</property>
+					<value>25</value>
+				</greater-than-equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp1-standby</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.14896</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">%s</format>
+		<property>controls/radio/rmp[0]/standby-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- Test Illumination-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp1-standby-test</object-name>
+		<condition>
+			<equals>
+				<property>controls/switches/annun-test</property>
+				<value>1</value>
+			</equals>
+		</condition>
+	</animation>
+
+        <text>
+                <name>rmp1-standby-test</name>
+                <offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.14896</y-m>
+			<z-m>-0.12613</z-m>
+                        <heading-deg>90</heading-deg>
+                </offsets>
+                <alignment>center-center</alignment>
+                <axis-alignment>xy-plane</axis-alignment>
+                <type type="string">text-value</type>
+                <format type="string">888.888</format>
+                <property>autopilot/servicable</property>
+                <truncate type="bool">false</truncate>
+                <font type="string">led.txf</font>
+                <draw-text type="bool">true</draw-text>
+                <draw-alignment type="bool">false</draw-alignment>
+                <draw-boundingbox type="bool">false</draw-boundingbox>
+                <character-size>0.008</character-size>
+                <font-resolution>
+                        <width type="int">32</width>
+                        <height type="int">32</height>
+                </font-resolution>
+        </text>
 </PropertyList>

--- a/Models/Instruments/Radio/Radio1.xml
+++ b/Models/Instruments/Radio/Radio1.xml
@@ -1407,30 +1407,30 @@
 		</condition>
 	</animation>
 
-        <text>
-                <name>rmp1-active-test</name>
-                <offsets>
+	<text>
+		<name>rmp1-active-test</name>
+		<offsets>
 			<x-m>-0.22190</x-m>
 			<y-m>-0.21549</y-m>
 			<z-m>-0.12613</z-m>
-                        <heading-deg>90</heading-deg>
-                </offsets>
-                <alignment>center-center</alignment>
-                <axis-alignment>xy-plane</axis-alignment>
-                <type type="string">text-value</type>
-                <format type="string">888.888</format>
-                <property>autopilot/servicable</property>
-                <truncate type="bool">false</truncate>
-                <font type="string">led.txf</font>
-                <draw-text type="bool">true</draw-text>
-                <draw-alignment type="bool">false</draw-alignment>
-                <draw-boundingbox type="bool">false</draw-boundingbox>
-                <character-size>0.008</character-size>
-                <font-resolution>
-                        <width type="int">32</width>
-                        <height type="int">32</height>
-                </font-resolution>
-        </text>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">888.888</format>
+		<property>autopilot/servicable</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
 
 	<!-- STBY Display -->
 	<animation>
@@ -1491,28 +1491,28 @@
 		</condition>
 	</animation>
 
-        <text>
-                <name>rmp1-standby-test</name>
-                <offsets>
+	<text>
+		<name>rmp1-standby-test</name>
+		<offsets>
 			<x-m>-0.22190</x-m>
 			<y-m>-0.14896</y-m>
 			<z-m>-0.12613</z-m>
-                        <heading-deg>90</heading-deg>
-                </offsets>
-                <alignment>center-center</alignment>
-                <axis-alignment>xy-plane</axis-alignment>
-                <type type="string">text-value</type>
-                <format type="string">888.888</format>
-                <property>autopilot/servicable</property>
-                <truncate type="bool">false</truncate>
-                <font type="string">led.txf</font>
-                <draw-text type="bool">true</draw-text>
-                <draw-alignment type="bool">false</draw-alignment>
-                <draw-boundingbox type="bool">false</draw-boundingbox>
-                <character-size>0.008</character-size>
-                <font-resolution>
-                        <width type="int">32</width>
-                        <height type="int">32</height>
-                </font-resolution>
-        </text>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">888.888</format>
+		<property>autopilot/servicable</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
 </PropertyList>

--- a/Models/Instruments/Radio/Radio1.xml
+++ b/Models/Instruments/Radio/Radio1.xml
@@ -318,6 +318,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -455,6 +461,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -594,6 +606,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -730,6 +748,12 @@
 							<property>systems/radio/rmp[0]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[0]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -1366,6 +1390,18 @@
 					<property>systems/electrical/bus/dc-ess</property>
 					<value>25</value>
 				</greater-than-equals>
+				<not>
+					<and>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>instrumentation/comm[2]/frequencies/selected-mhz</property>
+							<value>0</value>
+						</equals>
+					</and>
+				</not>
 			</and>
 		</condition>
 	</animation>
@@ -1383,6 +1419,61 @@
 		<type type="string">text-value</type>
 		<format type="string">%s</format>
 		<property>controls/radio/rmp[0]/active-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- VHF3 Data Mode-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp1-active-vhf3-data</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[0]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc-ess</property>
+					<value>25</value>
+				</greater-than-equals>
+				<equals>
+					<property>systems/radio/rmp[0]/sel_chan</property>
+					<value type="string">vhf3</value>
+				</equals>
+				<equals>
+					<property>instrumentation/comm[2]/frequencies/selected-mhz</property>
+					<value>0</value>
+				</equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp1-active-vhf3-data</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.21549</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">data</format>
+		<property>autopilot/servicable</property>
 		<truncate type="bool">false</truncate>
 		<font type="string">led.txf</font>
 		<draw-text type="bool">true</draw-text>
@@ -1450,6 +1541,18 @@
 					<property>systems/electrical/bus/dc-ess</property>
 					<value>25</value>
 				</greater-than-equals>
+				<not>
+					<and>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/vhf3-standby</property>
+							<value>0</value>
+						</equals>
+					</and>
+				</not>
 			</and>
 		</condition>
 	</animation>
@@ -1467,6 +1570,61 @@
 		<type type="string">text-value</type>
 		<format type="string">%s</format>
 		<property>controls/radio/rmp[0]/standby-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- VHF3 Data Mode-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp1-standby-vhf3-data</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[0]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc-ess</property>
+					<value>25</value>
+				</greater-than-equals>
+				<equals>
+					<property>systems/radio/rmp[0]/sel_chan</property>
+					<value type="string">vhf3</value>
+				</equals>
+				<equals>
+					<property>systems/radio/rmp[0]/vhf3-standby</property>
+					<value>0</value>
+				</equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp1-standby-vhf3-data</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.14896</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">data</format>
+		<property>autopilot/servicable</property>
 		<truncate type="bool">false</truncate>
 		<font type="string">led.txf</font>
 		<draw-text type="bool">true</draw-text>

--- a/Models/Instruments/Radio/Radio2.xml
+++ b/Models/Instruments/Radio/Radio2.xml
@@ -1407,30 +1407,30 @@
 		</condition>
 	</animation>
 
-        <text>
-                <name>rmp2-active-test</name>
-                <offsets>
+	<text>
+		<name>rmp2-active-test</name>
+		<offsets>
 			<x-m>-0.22190</x-m>
 			<y-m>-0.21549</y-m>
 			<z-m>-0.12613</z-m>
-                        <heading-deg>90</heading-deg>
-                </offsets>
-                <alignment>center-center</alignment>
-                <axis-alignment>xy-plane</axis-alignment>
-                <type type="string">text-value</type>
-                <format type="string">888.888</format>
-                <property>autopilot/servicable</property>
-                <truncate type="bool">false</truncate>
-                <font type="string">led.txf</font>
-                <draw-text type="bool">true</draw-text>
-                <draw-alignment type="bool">false</draw-alignment>
-                <draw-boundingbox type="bool">false</draw-boundingbox>
-                <character-size>0.008</character-size>
-                <font-resolution>
-                        <width type="int">32</width>
-                        <height type="int">32</height>
-                </font-resolution>
-        </text>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">888.888</format>
+		<property>autopilot/servicable</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
 
 	<!-- STBY Display -->
 	<animation>
@@ -1491,28 +1491,28 @@
 		</condition>
 	</animation>
 
-        <text>
-                <name>rmp2-standby-test</name>
-                <offsets>
+	<text>
+		<name>rmp2-standby-test</name>
+		<offsets>
 			<x-m>-0.22190</x-m>
 			<y-m>-0.14896</y-m>
 			<z-m>-0.12613</z-m>
-                        <heading-deg>90</heading-deg>
-                </offsets>
-                <alignment>center-center</alignment>
-                <axis-alignment>xy-plane</axis-alignment>
-                <type type="string">text-value</type>
-                <format type="string">888.888</format>
-                <property>autopilot/servicable</property>
-                <truncate type="bool">false</truncate>
-                <font type="string">led.txf</font>
-                <draw-text type="bool">true</draw-text>
-                <draw-alignment type="bool">false</draw-alignment>
-                <draw-boundingbox type="bool">false</draw-boundingbox>
-                <character-size>0.008</character-size>
-                <font-resolution>
-                        <width type="int">32</width>
-                        <height type="int">32</height>
-                </font-resolution>
-        </text>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">888.888</format>
+		<property>autopilot/servicable</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
 </PropertyList>

--- a/Models/Instruments/Radio/Radio2.xml
+++ b/Models/Instruments/Radio/Radio2.xml
@@ -318,6 +318,12 @@
 							<property>systems/radio/rmp[1]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -455,6 +461,12 @@
 							<property>systems/radio/rmp[1]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -594,6 +606,12 @@
 							<property>systems/radio/rmp[1]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -730,6 +748,12 @@
 							<property>systems/radio/rmp[1]/sel_chan</property>
 							<value type="string">vhf3</value>
 						</equals>
+						<not>
+							<equals>
+								<property>systems/radio/rmp[1]/vhf3-standby</property>
+								<value>0</value>
+							</equals>
+						</not>
 					</and>
 				</condition>
 				<command>property-adjust</command>
@@ -1366,6 +1390,18 @@
 					<property>systems/electrical/bus/dc2</property>
 					<value>25</value>
 				</greater-than-equals>
+				<not>
+					<and>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>instrumentation/comm[2]/frequencies/selected-mhz</property>
+							<value>0</value>
+						</equals>
+					</and>
+				</not>
 			</and>
 		</condition>
 	</animation>
@@ -1383,6 +1419,61 @@
 		<type type="string">text-value</type>
 		<format type="string">%s</format>
 		<property>controls/radio/rmp[1]/active-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- VHF3 Data Mode-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp2-active-vhf3-data</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[1]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc2</property>
+					<value>25</value>
+				</greater-than-equals>
+				<equals>
+					<property>systems/radio/rmp[1]/sel_chan</property>
+					<value type="string">vhf3</value>
+				</equals>
+				<equals>
+					<property>instrumentation/comm[2]/frequencies/selected-mhz</property>
+					<value>0</value>
+				</equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp2-active-vhf3-data</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.21549</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">data</format>
+		<property>autopilot/servicable</property>
 		<truncate type="bool">false</truncate>
 		<font type="string">led.txf</font>
 		<draw-text type="bool">true</draw-text>
@@ -1450,6 +1541,18 @@
 					<property>systems/electrical/bus/dc2</property>
 					<value>25</value>
 				</greater-than-equals>
+				<not>
+					<and>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/vhf3-standby</property>
+							<value>0</value>
+						</equals>
+					</and>
+				</not>
 			</and>
 		</condition>
 	</animation>
@@ -1467,6 +1570,61 @@
 		<type type="string">text-value</type>
 		<format type="string">%s</format>
 		<property>controls/radio/rmp[1]/standby-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- VHF3 Data Mode-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp2-standby-vhf3-data</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[1]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc-ess</property>
+					<value>25</value>
+				</greater-than-equals>
+				<equals>
+					<property>systems/radio/rmp[1]/sel_chan</property>
+					<value type="string">vhf3</value>
+				</equals>
+				<equals>
+					<property>systems/radio/rmp[1]/vhf3-standby</property>
+					<value>0</value>
+				</equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp2-standby-vhf3-data</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.14896</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">data</format>
+		<property>autopilot/servicable</property>
 		<truncate type="bool">false</truncate>
 		<font type="string">led.txf</font>
 		<draw-text type="bool">true</draw-text>

--- a/Models/Instruments/Radio/Radio2.xml
+++ b/Models/Instruments/Radio/Radio2.xml
@@ -1,13 +1,1518 @@
-<?xml version="1.0"?>
-
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
-##############################################
-# Copyright (c) Joshua Davidson (it0uchpods) #
-##############################################
+############################
+# Copyright (c) merspieler #
+############################
 -->
+
 
 <PropertyList>
 
 	<path>res/Radio1.ac</path>
-	
+
+	<!-- On Switch -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_on</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>false</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>controls/radio/rmp[1]/on</property>
+			</binding>
+		</action>
+	</animation>
+	<animation>
+		<type>rotate</type>
+		<object-name>radio_on</object-name>
+		<property>controls/radio/rmp[1]/on</property>
+		<interpolation>
+			<entry>
+				<ind>0</ind>
+				<dep>20</dep>
+			</entry>
+			<entry>
+				<ind>1</ind>
+				<dep>-20</dep>
+			</entry>
+		</interpolation>
+		<axis>
+			<object-name>radio_on.axis</object-name>
+		</axis>
+	</animation>
+
+	<!-- VHF1 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vhf1</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>vhf1</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- VHF2 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vhf2</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>vhf2</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- VHF3 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vhf3</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>vhf3</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- HF1 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_hf1</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>hf1</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- HF2 -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_hf2</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>hf2</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- AM Mode -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_am</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>systems/radio/rmp[1]/am-active</property>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<or>
+							<equals>
+								<property>systems/radio/rmp[1]/sel_chan</property>
+								<value>hf1</value>
+							</equals>
+							<equals>
+								<property>systems/radio/rmp[1]/sel_chan</property>
+								<value>hf2</value>
+							</equals>
+						</or>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- Transfer -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_exchange</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>nasal</command>
+				<script>rmp.transfer(2);</script>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- Knob -->
+	<!-- TODO add bindings for VOR, LS and ADF -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_rot1</object-name>
+		<action>
+			<button>0</button>
+			<button>3</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf1-standby</property>
+				<step>0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf2-standby</property>
+				<step>0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf3-standby</property>
+				<step>0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf1-standby</property>
+				<step>1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf2-standby</property>
+				<step>1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+		</action>
+		<action>
+			<button>1</button>
+			<button>4</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf1-standby</property>
+				<step>-0.025</step>
+				<min>0.0</min>
+				<max>1.0</max>
+				<resolution>0.025</resolution>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf2-standby</property>
+				<step>-0.025</step>
+				<resolution>0.025</resolution>
+				<min>0.0</min>
+				<max>1.0</max>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf3-standby</property>
+				<step>-0.025</step>
+				<resolution>0.025</resolution>
+				<min>0.0</min>
+				<max>1.0</max>
+				<wrap>true</wrap>
+				<mask>decimal</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf1-standby</property>
+				<step>-1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf2-standby</property>
+				<step>-1</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+			</binding>
+
+		</action>
+	</animation>
+	<animation>
+		<type>pick</type>
+		<object-name>radio_rot0</object-name>
+		<action>
+			<button>0</button>
+			<button>3</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf1-standby</property>
+				<step>1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf2-standby</property>
+				<step>1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf3-standby</property>
+				<step>1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf1-standby</property>
+				<step>100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf2-standby</property>
+				<step>100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+		</action>
+		<action>
+			<button>1</button>
+			<button>4</button>
+			<repeatable>true</repeatable>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf1-standby</property>
+				<step>-1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf2-standby</property>
+				<step>-1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/vhf3-standby</property>
+				<step>-1</step>
+				<min>118.0</min>
+				<max>137.0</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf1-standby</property>
+				<step>-100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+			<binding>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+					</and>
+				</condition>
+				<command>property-adjust</command>
+				<property>systems/radio/rmp[1]/hf2-standby</property>
+				<step>-100</step>
+				<min>200</min>
+				<max>1800</max>
+				<wrap>true</wrap>
+				<mask>integer</mask>
+			</binding>
+
+		</action>
+	</animation>
+
+	<!-- NAV Protector -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_nav_lit</object-name>
+		<action>
+			<button>1</button>
+			<binding>
+				<command>property-assign</command>
+				<property>controls/radio/rmp[1]/nav-protect</property>
+				<value>1</value>
+			</binding>
+			<mod-up>
+				<binding>
+					<command>property-assign</command>
+					<property>controls/radio/rmp[1]/nav-protect</property>
+					<value>0</value>
+				</binding>
+				<binding>
+					<command>nasal</command>
+					<script>setprop("/sim/sounde/oh-cover", 1);</script>
+				</binding>
+			</mod-up>
+		</action>
+	</animation>
+	<animation>
+		<type>rotate</type>
+		<object-name>radio_nav_lit</object-name>
+		<property>controls/radio/rmp[1]/nav-protect</property>
+		<factor>-90</factor>
+		<axis>
+			<object-name>radio_nav_lit.axis</object-name>
+		</axis>
+	</animation>
+
+	<!-- NAV -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_nav</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>systems/radio/rmp[1]/nav</property>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>controls/radio/rmp[1]/nav-protect</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- STBY NAV -->
+	<animation>
+		<type>pick</type>
+		<object-name>radio_vor</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>vor</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/nav</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<animation>
+		<type>pick</type>
+		<object-name>radio_ls</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>ls</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/nav</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<animation>
+		<type>pick</type>
+		<object-name>radio_adf</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-assign</command>
+				<property>systems/radio/rmp[1]/sel_chan</property>
+				<value>adf</value>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/nav</property>
+							<value>1</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<animation>
+		<type>pick</type>
+		<object-name>radio_bfo</object-name>
+		<action>
+			<button>0</button>
+			<repeatable>true</repeatable>
+			<binding>
+				<command>property-toggle</command>
+				<property>systems/radio/rmp[1]/bfo-active</property>
+				<condition>
+					<and>
+						<greater-than-equals>
+							<property>systems/electrical/bus/dc2</property>
+							<value>25</value>
+						</greater-than-equals>
+						<equals>
+							<property>controls/radio/rmp[1]/on</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/nav</property>
+							<value>1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value>adf</value>
+						</equals>
+					</and>
+				</condition>
+			</binding>
+		</action>
+	</animation>
+
+	<!-- SEL Light -->
+	<animation>
+		<type>select</type>
+		<object-name>radio_sel_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+					<or>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[0]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">vhf3</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[1]/sel_chan</property>
+							<value type="string">hf2</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[2]/sel_chan</property>
+							<value type="string">vhf1</value>
+						</equals>
+						<equals>
+							<property>systems/radio/rmp[2]/sel_chan</property>
+							<value type="string">vhf2</value>
+						</equals>
+					</or>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<!-- Status Lights -->
+	<animation>
+		<type>select</type>
+		<object-name>radio_vhf1_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">vhf1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_vhf2_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">vhf2</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_vhf3_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">vhf3</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_hf1_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">hf1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_hf2_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">hf2</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_nav_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/nav</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_vor_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">vor</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_ls_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">ls</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_adf_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/sel_chan</property>
+						<value type="string">adf</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_bfo_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/bfo-active</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<animation>
+		<type>select</type>
+		<object-name>radio_am_led</object-name>
+		<condition>
+			<or>
+				<equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</equals>
+				<and>
+					<greater-than-equals>
+						<property>systems/electrical/bus/dc2</property>
+						<value>25</value>
+					</greater-than-equals>
+					<equals>
+						<property>systems/radio/rmp[1]/am-active</property>
+						<value>1</value>
+					</equals>
+					<equals>
+						<property>controls/radio/rmp[1]/on</property>
+						<value>1</value>
+					</equals>
+				</and>
+			</or>
+		</condition>
+	</animation>
+
+	<!-- Active Display -->
+	<animation>
+		<type>select</type>
+		<object-name>rmp2-active</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[1]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc2</property>
+					<value>25</value>
+				</greater-than-equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp2-active</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.21549</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">%s</format>
+		<property>controls/radio/rmp[1]/active-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- Test Illumination-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp2-active-test</object-name>
+		<condition>
+			<equals>
+				<property>controls/switches/annun-test</property>
+				<value>1</value>
+			</equals>
+		</condition>
+	</animation>
+
+        <text>
+                <name>rmp2-active-test</name>
+                <offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.21549</y-m>
+			<z-m>-0.12613</z-m>
+                        <heading-deg>90</heading-deg>
+                </offsets>
+                <alignment>center-center</alignment>
+                <axis-alignment>xy-plane</axis-alignment>
+                <type type="string">text-value</type>
+                <format type="string">888.888</format>
+                <property>autopilot/servicable</property>
+                <truncate type="bool">false</truncate>
+                <font type="string">led.txf</font>
+                <draw-text type="bool">true</draw-text>
+                <draw-alignment type="bool">false</draw-alignment>
+                <draw-boundingbox type="bool">false</draw-boundingbox>
+                <character-size>0.008</character-size>
+                <font-resolution>
+                        <width type="int">32</width>
+                        <height type="int">32</height>
+                </font-resolution>
+        </text>
+
+	<!-- STBY Display -->
+	<animation>
+		<type>select</type>
+		<object-name>rmp2-standby</object-name>
+		<condition>
+			<and>
+				<not-equals>
+					<property>controls/switches/annun-test</property>
+					<value>1</value>
+				</not-equals>
+				<equals>
+					<property>controls/radio/rmp[1]/on</property>
+					<value>1</value>
+				</equals>
+				<greater-than-equals>
+					<property>systems/electrical/bus/dc2</property>
+					<value>25</value>
+				</greater-than-equals>
+			</and>
+		</condition>
+	</animation>
+
+	<text>
+		<name>rmp2-standby</name>
+		<offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.14896</y-m>
+			<z-m>-0.12613</z-m>
+			<heading-deg>90</heading-deg>
+		</offsets>
+		<alignment>center-center</alignment>
+		<axis-alignment>xy-plane</axis-alignment>
+		<type type="string">text-value</type>
+		<format type="string">%s</format>
+		<property>controls/radio/rmp[1]/standby-display</property>
+		<truncate type="bool">false</truncate>
+		<font type="string">led.txf</font>
+		<draw-text type="bool">true</draw-text>
+		<draw-alignment type="bool">false</draw-alignment>
+		<draw-boundingbox type="bool">false</draw-boundingbox>
+		<character-size>0.008</character-size>
+		<font-resolution>
+			<width type="int">32</width>
+			<height type="int">32</height>
+		</font-resolution>
+	</text>
+
+	<!-- Test Illumination-->
+	<animation>
+		<type>select</type>
+		<object-name>rmp2-standby-test</object-name>
+		<condition>
+			<equals>
+				<property>controls/switches/annun-test</property>
+				<value>1</value>
+			</equals>
+		</condition>
+	</animation>
+
+        <text>
+                <name>rmp2-standby-test</name>
+                <offsets>
+			<x-m>-0.22190</x-m>
+			<y-m>-0.14896</y-m>
+			<z-m>-0.12613</z-m>
+                        <heading-deg>90</heading-deg>
+                </offsets>
+                <alignment>center-center</alignment>
+                <axis-alignment>xy-plane</axis-alignment>
+                <type type="string">text-value</type>
+                <format type="string">888.888</format>
+                <property>autopilot/servicable</property>
+                <truncate type="bool">false</truncate>
+                <font type="string">led.txf</font>
+                <draw-text type="bool">true</draw-text>
+                <draw-alignment type="bool">false</draw-alignment>
+                <draw-boundingbox type="bool">false</draw-boundingbox>
+                <character-size>0.008</character-size>
+                <font-resolution>
+                        <width type="int">32</width>
+                        <height type="int">32</height>
+                </font-resolution>
+        </text>
 </PropertyList>

--- a/Models/Instruments/Radio/Radio2.xml
+++ b/Models/Instruments/Radio/Radio2.xml
@@ -1597,7 +1597,7 @@
 					<value>1</value>
 				</equals>
 				<greater-than-equals>
-					<property>systems/electrical/bus/dc-ess</property>
+					<property>systems/electrical/bus/dc2</property>
 					<value>25</value>
 				</greater-than-equals>
 				<equals>

--- a/Nasal/libraries.nas
+++ b/Nasal/libraries.nas
@@ -193,6 +193,7 @@ var systemsInit = func {
 	libraries.ECAM.init();
 	libraries.BUTTONS.init();
 	libraries.variousReset();
+	rmp.init();
 }
 
 setlistener("/sim/signals/fdm-initialized", func {

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -76,6 +76,11 @@ file, these values will be used (they are hardcoded).
 		<number>1</number>
 	</comm-radio>
 
+	<comm-radio>
+		<name>comm</name>
+		<number>2</number>
+	</comm-radio>
+
 	<dme>
 		<name>dme</name>
 		<number>0</number>


### PR DESCRIPTION
### Description of Changes
* Added VHF1, VHF2 and VHF3 fully functional
* All Channel keys selectable

### TODO
* Cosmetic stuff
* Add the RMPs to the autostart and shutdown sequences
* Add power consumption (RMP1 on DC-ESS, RMP2 on DC-2)
* HF and STBY NAV dialing
* When `/instrumentation/comm[2]/frequencies/selected-mhz` != 0 display ecam messages:
    * On the right side `VHF3 VOICE`
    * On the left side `COMPANY DATALINK STBY`

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [x] Please have an IDG Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->