### PR TITLE
Added flashlight, turned on/off by `L` key

### DIFF
--- a/A320-main.xml
+++ b/A320-main.xml
@@ -1420,6 +1420,16 @@
 					<value>0</value>
 				</binding>
 			</key>
+			<key n="108">
+				<name>l</name>
+				<desc>Flashlight</desc>
+				<binding>
+					<command>property-cycle</command>
+					<property>sim/rendering/als-secondary-lights/use-flashlight</property>
+					<value>0</value>
+					<value>1</value>
+				</binding>
+			</key>
 		</keyboard>
 	</input>
 	

--- a/Models/Effects/IDG-A32X-interior.eff
+++ b/Models/Effects/IDG-A32X-interior.eff
@@ -18,5 +18,9 @@
 		<opacity-cube-center type="vec3d" n="0"> 0.6 0.0 0.7</opacity-cube-center>
 		<opacity-cube-scale type="vec3d" n="0"> 1 1 1</opacity-cube-scale>
 		<opacity-cube-angle type="float">0.0</opacity-cube-angle>
+
+		<light-filter-one type="vec3d">0.5 0.5 0.5</light-filter-one>
+		<light-filter-two type="vec3d">0.9 0.2 0.2</light-filter-two>
+		<light-radius type="float">9</light-radius>
 	</parameters>
 </PropertyList>


### PR DESCRIPTION
Signed-off-by: merspieler <merspieler@airmail.cc>

<!-- Give a brief summary of your changes in the title. -->

### Description of Changes
<!-- Describe your changes in detail. -->
Toggles flashlight on `L` key hit.
If you want to have the flashlight to shine out side, add another binding to the key with following content:
```
<command>property-toggle</command>
<property>sim/rendering/als-secondary-lights/use-searchlight</property>
```

### Screenshots (optional)

### Bugs fixed (if any)
<!-- If you fixed any bugs, describe them here. State issue number if applicable. -->

### Checklist:
<!-- [ ] = Unchecked, [x] = Checked. -->
* [x] My changes follow the Contributing Guidelines. <!-- See CONTRIBUTING.md to verify. -->
* [x] My changes implement realistic features. <!-- Only aircraft changes require this. -->
* [ ] Please have an IDG Developer test my changes before merging. <!-- We will always briefly test, but if it needs a "full" test, please check). -->
* [x] My changes are ready for merging. <!-- Uncheck if you want to decide when to merge. -->